### PR TITLE
Define @spec for all functions

### DIFF
--- a/lib/oauther.ex
+++ b/lib/oauther.ex
@@ -12,8 +12,11 @@ defmodule OAuther do
                :token, :token_secret, method: :hmac_sha1]
   end
 
-  @type http_header :: {String.t, any}
-  @type params :: [{String.t, any}]
+  @type pair_of_strings :: {String.t, String.t}
+  @type header :: {String.t, any}
+  @type headers :: [header]
+  @type param :: {String.t, any}
+  @type params :: [param]
 
   @spec credentials(Enumerable.t) :: Credentials.t
   def credentials(args) do
@@ -22,7 +25,7 @@ defmodule OAuther do
     end)
   end
 
-  @spec sign(String.t, String.t | URI.t, params, Credentials.t) :: [http_header]
+  @spec sign(String.t, String.t | URI.t, params, Credentials.t) :: headers
   def sign(verb, url, params, %Credentials{} = creds) do
     params = protocol_params(params, creds)
     signature = signature(verb, url, params, creds)
@@ -30,14 +33,14 @@ defmodule OAuther do
     [{"oauth_signature", signature} | params]
   end
 
-  @spec header(Enumerable.t) :: {{String.t, String.t}, [http_header]}
+  @spec header(params) :: {pair_of_strings, headers}
   def header(params) do
     {oauth_params, req_params} = Enum.partition(params, &protocol_param?/1)
 
     {{"Authorization", "OAuth " <> compose_header(oauth_params)}, req_params}
   end
 
-  @spec protocol_params(params, Credentials.t) :: [{String.t, any}]
+  @spec protocol_params(params, Credentials.t) :: params
   def protocol_params(params, %Credentials{} = creds) do
     [{"oauth_consumer_key",     creds.consumer_key},
      {"oauth_nonce",            nonce},
@@ -63,11 +66,12 @@ defmodule OAuther do
     |> Base.encode64
   end
 
-  @spec protocol_param?({String.t, any}) :: boolean
+  @spec protocol_param?(param) :: boolean
   defp protocol_param?({key, _v}) do
     String.starts_with?(key, "oauth_")
   end
 
+  @spec compose_header(nonempty_list(param | term)) :: String.t
   defp compose_header([_ | _] = params) do
     Stream.map(params, &percent_encode/1)
     |> Enum.map_join(", ", &compose_header/1)
@@ -77,17 +81,20 @@ defmodule OAuther do
     key <> "=\"" <> value <> "\""
   end
 
+  @spec compose_key(Credentials.t) :: String.t
   defp compose_key(creds) do
     [creds.consumer_secret, creds.token_secret]
     |> Enum.map_join("&", &percent_encode/1)
   end
 
+  @spec read_private_key(Path.t) :: term
   defp read_private_key(path) do
     File.read!(path)
     |> :public_key.pem_decode
     |> hd() |> :public_key.pem_entry_decode
   end
 
+  @spec base_string(String.t, String.t, params) :: String.t
   defp base_string(verb, url, params) do
     {uri, query_params} = parse_url(url)
     [verb, uri, params ++ query_params]
@@ -95,39 +102,48 @@ defmodule OAuther do
     |> Enum.map_join("&", &percent_encode/1)
   end
 
+  @spec normalize(String.t) :: String.t
   defp normalize(verb) when is_binary(verb),
     do: String.upcase(verb)
 
+  @spec normalize(URI.t) :: URI.t
   defp normalize(%URI{host: host} = uri),
     do: %{uri | host: String.downcase(host)}
 
+  @spec normalize(nonempty_list(param)) :: String.t
   defp normalize([_ | _] = params) do
     Enum.map(params, &percent_encode/1)
     |> Enum.sort
     |> Enum.map_join("&", &normalize_pair/1)
   end
 
+  @spec normalize_pair(pair_of_strings) :: String.t
   defp normalize_pair({key, value}) do
     key <> "=" <> value
   end
 
+  @spec parse_url(String.t) :: {URI.t, [pair_of_strings]}
   defp parse_url(url) do
     uri = URI.parse(url)
     {%{uri | query: nil}, parse_query_params(uri.query)}
   end
 
+  @spec parse_query_params(nil) :: []
   def parse_query_params(nil), do: []
 
+  @spec parse_query_params(params) :: [pair_of_strings]
   def parse_query_params(params) do
     URI.query_decoder(params)
     |> Enum.into([])
   end
 
+  @spec nonce() :: binary
   defp nonce() do
     :crypto.rand_bytes(32)
     |> Base.encode64
   end
 
+  @spec timestamp() :: non_neg_integer
   defp timestamp() do
     {mgsec, sec, _mcs} = :os.timestamp
 

--- a/lib/oauther.ex
+++ b/lib/oauther.ex
@@ -150,18 +150,22 @@ defmodule OAuther do
     mgsec * 1_000_000 + sec
   end
 
+  @spec cons_token(params, param) :: params
   defp cons_token(params, nil), do: params
   defp cons_token(params, value),
     do: [{"oauth_token", value} | params]
 
+  @spec sign_method(:plaintext | :hmac_sha1 | :rsa_sha1) :: String.t
   defp sign_method(:plaintext), do: "PLAINTEXT"
   defp sign_method(:hmac_sha1), do: "HMAC-SHA1"
   defp sign_method(:rsa_sha1),  do: "RSA-SHA1"
 
+  # @spec percent_encode(param) :: pair_of_strings
   defp percent_encode({key, value}) do
     {percent_encode(key), percent_encode(value)}
   end
 
+  # @spec percent_encode(any) :: String.t
   defp percent_encode(term) do
     to_string(term)
     |> URI.encode(&URI.char_unreserved?/1)

--- a/lib/oauther.ex
+++ b/lib/oauther.ex
@@ -12,6 +12,7 @@ defmodule OAuther do
                :token, :token_secret, method: :hmac_sha1]
   end
 
+  @spec credentials(Enumerable.t) :: Credentials.t
   def credentials(args) do
     Enum.reduce(args, %Credentials{}, fn({key, val}, acc) ->
       :maps.update(key, val, acc)

--- a/lib/oauther.ex
+++ b/lib/oauther.ex
@@ -19,6 +19,7 @@ defmodule OAuther do
     end)
   end
 
+  @spec sign(String.t, String.t | URI.t, [{String.t, any}], Credentials.t) :: [{String.t, any}]
   def sign(verb, url, params, %Credentials{} = creds) do
     params = protocol_params(params, creds)
     signature = signature(verb, url, params, creds)

--- a/lib/oauther.ex
+++ b/lib/oauther.ex
@@ -1,11 +1,11 @@
 defmodule OAuther do
   defmodule Credentials do
     @type t :: %__MODULE__{
-      consumer_key: String.t,
+      consumer_key:    String.t,
       consumer_secret: String.t,
-      token: String.t,
-      token_secret: String.t,
-      method: :hmac_sha1 | :rsa_sha1 | :plaintext
+      token:           String.t,
+      token_secret:    String.t,
+      method:          :hmac_sha1 | :rsa_sha1 | :plaintext
     }
 
     defstruct [:consumer_key, :consumer_secret,

--- a/lib/oauther.ex
+++ b/lib/oauther.ex
@@ -1,5 +1,13 @@
 defmodule OAuther do
   defmodule Credentials do
+    @type t :: %__MODULE__{
+      consumer_key: String.t,
+      consumer_secret: String.t,
+      token: String.t,
+      token_secret: String.t,
+      method: :hmac_sha1 | :rsa_sha1 | :plaintext
+    }
+
     defstruct [:consumer_key, :consumer_secret,
                :token, :token_secret, method: :hmac_sha1]
   end

--- a/lib/oauther.ex
+++ b/lib/oauther.ex
@@ -12,6 +12,8 @@ defmodule OAuther do
                :token, :token_secret, method: :hmac_sha1]
   end
 
+  @type http_header :: {String.t, any}
+
   @spec credentials(Enumerable.t) :: Credentials.t
   def credentials(args) do
     Enum.reduce(args, %Credentials{}, fn({key, val}, acc) ->
@@ -19,7 +21,7 @@ defmodule OAuther do
     end)
   end
 
-  @spec sign(String.t, String.t | URI.t, [{String.t, any}], Credentials.t) :: [{String.t, any}]
+  @spec sign(String.t, String.t | URI.t, [{String.t, any}], Credentials.t) :: [http_header]
   def sign(verb, url, params, %Credentials{} = creds) do
     params = protocol_params(params, creds)
     signature = signature(verb, url, params, creds)
@@ -27,12 +29,14 @@ defmodule OAuther do
     [{"oauth_signature", signature} | params]
   end
 
+  @spec header(Enumerable.t) :: {{String.t, String.t}, [http_header]}
   def header(params) do
     {oauth_params, req_params} = Enum.partition(params, &protocol_param?/1)
 
     {{"Authorization", "OAuth " <> compose_header(oauth_params)}, req_params}
   end
 
+  @spec protocol_params([{String.t, any}], Credentials.t) :: [{String.t, any}]
   def protocol_params(params, %Credentials{} = creds) do
     [{"oauth_consumer_key",     creds.consumer_key},
      {"oauth_nonce",            nonce},

--- a/lib/oauther.ex
+++ b/lib/oauther.ex
@@ -13,6 +13,7 @@ defmodule OAuther do
   end
 
   @type http_header :: {String.t, any}
+  @type params :: [{String.t, any}]
 
   @spec credentials(Enumerable.t) :: Credentials.t
   def credentials(args) do
@@ -21,7 +22,7 @@ defmodule OAuther do
     end)
   end
 
-  @spec sign(String.t, String.t | URI.t, [{String.t, any}], Credentials.t) :: [http_header]
+  @spec sign(String.t, String.t | URI.t, params, Credentials.t) :: [http_header]
   def sign(verb, url, params, %Credentials{} = creds) do
     params = protocol_params(params, creds)
     signature = signature(verb, url, params, creds)
@@ -36,7 +37,7 @@ defmodule OAuther do
     {{"Authorization", "OAuth " <> compose_header(oauth_params)}, req_params}
   end
 
-  @spec protocol_params([{String.t, any}], Credentials.t) :: [{String.t, any}]
+  @spec protocol_params(params, Credentials.t) :: [{String.t, any}]
   def protocol_params(params, %Credentials{} = creds) do
     [{"oauth_consumer_key",     creds.consumer_key},
      {"oauth_nonce",            nonce},
@@ -46,6 +47,7 @@ defmodule OAuther do
      | cons_token(params, creds.token)]
   end
 
+  @spec signature(String.t, String.t, params, Credentials.t) :: binary
   def signature(_, _, _, %{method: :plaintext} = creds) do
     compose_key(creds)
   end
@@ -61,6 +63,7 @@ defmodule OAuther do
     |> Base.encode64
   end
 
+  @spec protocol_param?({String.t, any}) :: boolean
   defp protocol_param?({key, _v}) do
     String.starts_with?(key, "oauth_")
   end

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule OAuther.Mixfile do
      version: "1.0.2",
      elixir: ">= 0.14.1",
      description: description,
+     deps: deps,
      package: package]
   end
 
@@ -15,6 +16,10 @@ defmodule OAuther.Mixfile do
 
   defp description,
     do: "Library to authenticate with OAuth 1.0 protocol."
+
+  defp deps do
+    [{:dialyxir, "~> 0.3", only: [:dev]}]
+  end
 
   defp package do
     [files: ["lib", "mix.exs", "README.md", "LICENSE"],


### PR DESCRIPTION
Hi,

I was struggling a bit with the type signatures of some functions. Therefore, I thought it would be nice to add specs to all of them.

I couldn't find a way to spec the percent_encode function. Dialyzer complains when I uncomment my original attempt.

Also I added dialyzer to the mix dependencies.
