### PR TITLE
Add support optional realm in a header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /_build
 /deps
+.elixir_ls
 erl_crash.dump
 *.ez
 mix.lock

--- a/lib/oauther.ex
+++ b/lib/oauther.ex
@@ -42,6 +42,13 @@ defmodule OAuther do
     {{"Authorization", "OAuth " <> compose_header(oauth_params)}, req_params}
   end
 
+  @spec header(params, String.t()) :: {header, params}
+  def header(params, realm) do
+    {oauth_params, req_params} = split_with(params, &protocol_param?/1)
+
+    {{"Authorization", "OAuth " <> compose_header([{"realm", realm} | oauth_params])}, req_params}
+  end
+
   @spec protocol_params(params, Credentials.t()) :: params
   def protocol_params(params, %Credentials{} = creds) do
     [

--- a/test/oauther_test.exs
+++ b/test/oauther_test.exs
@@ -1,6 +1,17 @@
 defmodule OAutherTest do
   use ExUnit.Case
 
+  setup do
+    %{
+      credentials: [
+        {"oauth_consumer_key", "dpf43f3p2l4k3l03"},
+        {"oauth_signature_method", "PLAINTEXT"},
+        {"oauth_signature", "kd94hf93k423kf44&"},
+        {"build", "Luna Park"}
+      ]
+    }
+  end
+
   test "HMAC-SHA1 signature" do
     creds =
       OAuther.credentials(
@@ -66,18 +77,22 @@ defmodule OAutherTest do
     assert signature(params, creds, "/photos?size=large") == "dzTFIxhRqhwfFqoXYgo4+hoPr2M="
   end
 
-  test "Authorization header" do
-    {header, req_params} =
-      OAuther.header([
-        {"oauth_consumer_key", "dpf43f3p2l4k3l03"},
-        {"oauth_signature_method", "PLAINTEXT"},
-        {"oauth_signature", "kd94hf93k423kf44&"},
-        {"build", "Luna Park"}
-      ])
+  test "Authorization header", %{credentials: credentials} do
+    {header, req_params} = OAuther.header(credentials)
 
     assert header ==
              {"Authorization",
               ~S(OAuth oauth_consumer_key="dpf43f3p2l4k3l03", oauth_signature_method="PLAINTEXT", oauth_signature="kd94hf93k423kf44%26")}
+
+    assert req_params == [{"build", "Luna Park"}]
+  end
+
+  test "Auth header with a realm", %{credentials: credentials} do
+    {header, req_params} = OAuther.header(credentials, "company")
+
+    assert header ==
+             {"Authorization",
+              ~S(OAuth realm="company", oauth_consumer_key="dpf43f3p2l4k3l03", oauth_signature_method="PLAINTEXT", oauth_signature="kd94hf93k423kf44%26")}
 
     assert req_params == [{"build", "Luna Park"}]
   end


### PR DESCRIPTION
This parameter is optional, but some providers require it to be specified in the header.

Please see https://tools.ietf.org/html/rfc5849#section-3.5.1 for details.