### PR TITLE
Fix Elixir 1.11 Warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule OAuther.Mixfile do
   end
 
   def application() do
-    [applications: []]
+    [extra_applications: [:crypto, :public_key]]
   end
 
   defp description() do


### PR DESCRIPTION
During compilation, I get the warnings below repeatedly. It seems to be because we need to have `:crypto` and `:public_key` the `:extra_applications` config.

```
warning: :crypto.strong_rand_bytes/1 defined in application :crypto is used by the current application but the current application does not directly depend on :crypto. To fix this, you must do one of:

  1. If :crypto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :crypto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :crypto, you may optionally skip this warning by adding [xref: [exclude: :crypto]] to your "def project" in mix.exs

  lib/oauther.ex:151: OAuther.nonce/0

warning: :public_key.pem_decode/1 defined in application :public_key is used by the current application but the current application does not directly depend on :public_key. To fix this, you must do one of:

  1. If :public_key is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :public_key is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :public_key, you may optionally skip this warning by adding [xref: [exclude: :public_key]] to your "def project" in mix.exs

  lib/oauther.ex:105: OAuther.decode_private_key/1
```