### PR TITLE
add support for OTP-24

### DIFF
--- a/lib/oauther.ex
+++ b/lib/oauther.ex
@@ -60,8 +60,11 @@ defmodule OAuther do
   end
 
   def signature(verb, url, params, %Credentials{method: :hmac_sha1} = creds) do
-    :sha
-    |> :crypto.hmac(compose_key(creds), base_string(verb, url, params))
+    if function_exported?(:crypto, :mac, 4) do
+      :crypto.mac(:hmac, :sha, compose_key(creds), base_string(verb, url, params))
+    else
+      :crypto.hmac(:sha, compose_key(creds), base_string(verb, url, params))
+    end
     |> Base.encode64()
   end
 


### PR DESCRIPTION
`:crypto.hmac/3` was removed in favor of `:crypto.mac/4` which was added to in OTP 22.1.

This patch keeps the compatibility with OTP < 22.1 by checking if `:crypto.mac/4` is available.