### PR TITLE
Adjust for OTP 24 deprecation of Crypto functions

### DIFF
--- a/lib/oauther.ex
+++ b/lib/oauther.ex
@@ -72,8 +72,8 @@ defmodule OAuther do
     |> Base.encode64()
   end
 
-  Code.ensure_loaded?(:crypto) || IO.warn(":crypto module failed to load")
-  if function_exported?(:crypto, :mac, 4) do
+  # TODO: Remove this once we require at minimum OTP 22.
+  if Code.ensure_loaded?(:crypto) and function_exported?(:crypto, :mac, 4) do
     defp hmac_sha(key, data) do
       :crypto.mac(:hmac, :sha, key, data)
     end


### PR DESCRIPTION
Sames solution as https://github.com/lexmag/oauther/pull/22 but moved to compile time, and fixes an Elixir 1.12 warning as well about using `:public_key` without it being in the application list.

EDIT: dropped the public_key change since that has since been fixed


```
oauther ❯ asdf local erlang 24.0.5 && asdf local elixir 1.12.2-otp-24 && rm -rfv _build && mix test
removed '_build/test/lib/oauther/ebin/Elixir.OAuther.beam'
removed '_build/test/lib/oauther/ebin/Elixir.OAuther.Credentials.beam'
removed '_build/test/lib/oauther/ebin/oauther.app'
removed directory '_build/test/lib/oauther/ebin'
removed '_build/test/lib/oauther/.mix/compile.elixir_scm'
removed '_build/test/lib/oauther/.mix/compile.xref'
removed '_build/test/lib/oauther/.mix/compile.protocols'
removed '_build/test/lib/oauther/.mix/.mix_test_failures'
removed '_build/test/lib/oauther/.mix/compile.elixir'
removed directory '_build/test/lib/oauther/.mix'
removed '_build/test/lib/oauther/consolidated/Elixir.Enumerable.beam'
removed '_build/test/lib/oauther/consolidated/Elixir.String.Chars.beam'
removed '_build/test/lib/oauther/consolidated/Elixir.IEx.Info.beam'
removed '_build/test/lib/oauther/consolidated/Elixir.Collectable.beam'
removed '_build/test/lib/oauther/consolidated/Elixir.Inspect.beam'
removed '_build/test/lib/oauther/consolidated/Elixir.List.Chars.beam'
removed directory '_build/test/lib/oauther/consolidated'
removed directory '_build/test/lib/oauther'
removed directory '_build/test/lib'
removed directory '_build/test'
removed '_build/dev/lib/oauther/ebin/Elixir.OAuther.beam'
removed '_build/dev/lib/oauther/ebin/Elixir.OAuther.Credentials.beam'
removed '_build/dev/lib/oauther/ebin/oauther.app'
removed directory '_build/dev/lib/oauther/ebin'
removed '_build/dev/lib/oauther/.mix/compile.elixir_scm'
removed '_build/dev/lib/oauther/.mix/compile.app_tracer'
removed '_build/dev/lib/oauther/.mix/compile.protocols'
removed '_build/dev/lib/oauther/.mix/compile.elixir'
removed directory '_build/dev/lib/oauther/.mix'
removed '_build/dev/lib/oauther/consolidated/Elixir.Enumerable.beam'
removed '_build/dev/lib/oauther/consolidated/Elixir.String.Chars.beam'
removed '_build/dev/lib/oauther/consolidated/Elixir.IEx.Info.beam'
removed '_build/dev/lib/oauther/consolidated/Elixir.Collectable.beam'
removed '_build/dev/lib/oauther/consolidated/Elixir.Inspect.beam'
removed '_build/dev/lib/oauther/consolidated/Elixir.Phoenix.Param.beam'
removed '_build/dev/lib/oauther/consolidated/Elixir.List.Chars.beam'
removed directory '_build/dev/lib/oauther/consolidated'
removed directory '_build/dev/lib/oauther'
removed directory '_build/dev/lib'
removed directory '_build/dev'
removed directory '_build'
oauther ❯ mix test
Compiling 1 file (.ex)
Generated oauther app
.....

Finished in 0.07 seconds (0.00s async, 0.07s sync)
5 tests, 0 failures

Randomized with seed 313422
```

```
oauther ❯ asdf local erlang 21.3.8.17 && asdf local elixir 1.8.2-otp-21 && rm -rfv _build && mix test
removed '_build/test/lib/oauther/ebin/Elixir.OAuther.beam'
removed '_build/test/lib/oauther/ebin/Elixir.OAuther.Credentials.beam'
removed '_build/test/lib/oauther/ebin/oauther.app'
removed directory '_build/test/lib/oauther/ebin'
removed '_build/test/lib/oauther/.mix/compile.elixir_scm'
removed '_build/test/lib/oauther/.mix/compile.app_tracer'
removed '_build/test/lib/oauther/.mix/compile.protocols'
removed '_build/test/lib/oauther/.mix/.mix_test_failures'
removed '_build/test/lib/oauther/.mix/compile.elixir'
removed directory '_build/test/lib/oauther/.mix'
removed '_build/test/lib/oauther/consolidated/Elixir.Enumerable.beam'
removed '_build/test/lib/oauther/consolidated/Elixir.String.Chars.beam'
removed '_build/test/lib/oauther/consolidated/Elixir.IEx.Info.beam'
removed '_build/test/lib/oauther/consolidated/Elixir.Collectable.beam'
removed '_build/test/lib/oauther/consolidated/Elixir.Inspect.beam'
removed '_build/test/lib/oauther/consolidated/Elixir.Phoenix.Param.beam'
removed '_build/test/lib/oauther/consolidated/Elixir.List.Chars.beam'
removed directory '_build/test/lib/oauther/consolidated'
removed directory '_build/test/lib/oauther'
removed directory '_build/test/lib'
removed directory '_build/test'
removed directory '_build'
Compiling 1 file (.ex)
Generated oauther app
.....

Finished in 0.06 seconds
5 tests, 0 failures

Randomized with seed 631786
```