### PR TITLE
Add support for realm protocol param

### DIFF
--- a/lib/oauther.ex
+++ b/lib/oauther.ex
@@ -5,6 +5,7 @@ defmodule OAuther do
       :consumer_secret,
       :token,
       :token_secret,
+      realm: nil,
       method: :hmac_sha1
     ]
 
@@ -13,6 +14,7 @@ defmodule OAuther do
             consumer_secret: String.t(),
             token: nil | String.t(),
             token_secret: nil | String.t(),
+            realm: nil | String.t(),
             method: :hmac_sha1 | :hmac_sha256 | :rsa_sha1 | :plaintext
           }
   end
@@ -48,8 +50,10 @@ defmodule OAuther do
       {"oauth_signature_method", signature_method(creds.method)},
       {"oauth_timestamp", timestamp()},
       {"oauth_version", "1.0"}
-      | maybe_put_token(params, creds.token)
+      | params
     ]
+    |> maybe_add("oauth_token", creds.token)
+    |> maybe_add("realm", creds.realm)
   end
 
   @spec signature(String.t(), URI.t() | String.t(), params, Credentials.t()) :: binary
@@ -89,7 +93,7 @@ defmodule OAuther do
   end
 
   defp protocol_param?({key, _value}) do
-    String.starts_with?(key, "oauth_")
+    String.starts_with?(key, "oauth_") or key == "realm"
   end
 
   defp compose_header([_ | _] = params) do
@@ -174,13 +178,8 @@ defmodule OAuther do
     megasec * 1_000_000 + sec
   end
 
-  defp maybe_put_token(params, value) do
-    if is_nil(value) do
-      params
-    else
-      [{"oauth_token", value} | params]
-    end
-  end
+  defp maybe_add(params, _key, nil = _value), do: params
+  defp maybe_add(params, key, value), do: [{key, value} | params]
 
   defp signature_method(:plaintext), do: "PLAINTEXT"
   defp signature_method(:hmac_sha1), do: "HMAC-SHA1"

--- a/lib/oauther.ex
+++ b/lib/oauther.ex
@@ -22,9 +22,7 @@ defmodule OAuther do
 
   @spec credentials(Enumerable.t()) :: Credentials.t() | no_return
   def credentials(args) do
-    Enum.reduce(args, %Credentials{}, fn {key, val}, acc ->
-      :maps.update(key, val, acc)
-    end)
+    struct(Credentials, args)
   end
 
   @spec sign(String.t(), URI.t() | String.t(), params, Credentials.t()) :: params

--- a/test/oauther_test.exs
+++ b/test/oauther_test.exs
@@ -1,83 +1,85 @@
 defmodule OAutherTest do
   use ExUnit.Case
 
-  test "HMAC-SHA1 signature" do
-    creds =
-      OAuther.credentials(
-        consumer_secret: "kd94hf93k423kf44",
-        token_secret: "pfkkdhi9sl3r4s00",
-        consumer_key: "dpf43f3p2l4k3l03",
-        token: "nnch734d00sl2jdk"
-      )
+  describe "signature/4" do
+    test "HMAC-SHA1 signature" do
+      creds =
+        OAuther.credentials(
+          consumer_secret: "kd94hf93k423kf44",
+          token_secret: "pfkkdhi9sl3r4s00",
+          consumer_key: "dpf43f3p2l4k3l03",
+          token: "nnch734d00sl2jdk"
+        )
 
-    params = protocol_params(creds)
-    assert signature(params, creds, "/photos") == "tR3+Ty81lMeYAr/Fid0kMTYa/WM="
-  end
+      params = protocol_params(creds)
+      assert signature(params, creds, "/photos") == "tR3+Ty81lMeYAr/Fid0kMTYa/WM="
+    end
 
-  test "HMAC-SHA256 signature" do
-    creds =
-      OAuther.credentials(
-        method: :hmac_sha256,
-        consumer_secret: "kd94hf93k423kf44",
-        token_secret: "pfkkdhi9sl3r4s00",
-        consumer_key: "dpf43f3p2l4k3l03",
-        token: "nnch734d00sl2jdk"
-      )
+    test "HMAC-SHA256 signature" do
+      creds =
+        OAuther.credentials(
+          method: :hmac_sha256,
+          consumer_secret: "kd94hf93k423kf44",
+          token_secret: "pfkkdhi9sl3r4s00",
+          consumer_key: "dpf43f3p2l4k3l03",
+          token: "nnch734d00sl2jdk"
+        )
 
-    params = protocol_params(creds)
-    assert signature(params, creds, "/photos") == "WVPzl1j6ZsnkIjWr7e3OZ3jkenL57KwaLFhYsroX1hg="
-  end
+      params = protocol_params(creds)
+      assert signature(params, creds, "/photos") == "WVPzl1j6ZsnkIjWr7e3OZ3jkenL57KwaLFhYsroX1hg="
+    end
 
-  test "RSA-SHA1 signature" do
-    creds =
-      OAuther.credentials(
-        method: :rsa_sha1,
-        consumer_secret: fixture_path("private_key.pem"),
-        consumer_key: "dpf43f3p2l4k3l03"
-      )
+    test "RSA-SHA1 signature" do
+      creds =
+        OAuther.credentials(
+          method: :rsa_sha1,
+          consumer_secret: fixture_path("private_key.pem"),
+          consumer_key: "dpf43f3p2l4k3l03"
+        )
 
-    params = protocol_params(creds)
+      params = protocol_params(creds)
 
-    assert signature(params, creds, "/photos") ==
-             "cyZ9hTJnRfkOnF5+OzxXWKKG+hRY+/esxdQAluJem1RlHkZQRsFEevOS5x+A1ZoS+aYlTU3xdHkEKIb/+xuqaavAUFVaIF/5448XsXqSTJomvpoC1c7yw5ArNZnPRLYwK3XYHaIr5FHXbiCG/ze093i2MpsusQU6Shn8lGJNMWE="
+      assert signature(params, creds, "/photos") ==
+               "cyZ9hTJnRfkOnF5+OzxXWKKG+hRY+/esxdQAluJem1RlHkZQRsFEevOS5x+A1ZoS+aYlTU3xdHkEKIb/+xuqaavAUFVaIF/5448XsXqSTJomvpoC1c7yw5ArNZnPRLYwK3XYHaIr5FHXbiCG/ze093i2MpsusQU6Shn8lGJNMWE="
 
-    private_key = File.read!(fixture_path("private_key.pem"))
+      private_key = File.read!(fixture_path("private_key.pem"))
 
-    creds =
-      OAuther.credentials(
-        method: :rsa_sha1,
-        consumer_secret: private_key,
-        consumer_key: "dpf43f3p2l4k3l03"
-      )
+      creds =
+        OAuther.credentials(
+          method: :rsa_sha1,
+          consumer_secret: private_key,
+          consumer_key: "dpf43f3p2l4k3l03"
+        )
 
-    params = protocol_params(creds)
+      params = protocol_params(creds)
 
-    assert signature(params, creds, "/photos") ==
-             "cyZ9hTJnRfkOnF5+OzxXWKKG+hRY+/esxdQAluJem1RlHkZQRsFEevOS5x+A1ZoS+aYlTU3xdHkEKIb/+xuqaavAUFVaIF/5448XsXqSTJomvpoC1c7yw5ArNZnPRLYwK3XYHaIr5FHXbiCG/ze093i2MpsusQU6Shn8lGJNMWE="
-  end
+      assert signature(params, creds, "/photos") ==
+               "cyZ9hTJnRfkOnF5+OzxXWKKG+hRY+/esxdQAluJem1RlHkZQRsFEevOS5x+A1ZoS+aYlTU3xdHkEKIb/+xuqaavAUFVaIF/5448XsXqSTJomvpoC1c7yw5ArNZnPRLYwK3XYHaIr5FHXbiCG/ze093i2MpsusQU6Shn8lGJNMWE="
+    end
 
-  test "PLAINTEXT signature" do
-    creds =
-      OAuther.credentials(
-        method: :plaintext,
-        consumer_secret: "kd94hf93k423kf44",
-        consumer_key: "dpf43f3p2l4k3l03"
-      )
+    test "PLAINTEXT signature" do
+      creds =
+        OAuther.credentials(
+          method: :plaintext,
+          consumer_secret: "kd94hf93k423kf44",
+          consumer_key: "dpf43f3p2l4k3l03"
+        )
 
-    assert signature([], creds, "/photos") == "kd94hf93k423kf44&"
-  end
+      assert signature([], creds, "/photos") == "kd94hf93k423kf44&"
+    end
 
-  test "signature with query params" do
-    creds =
-      OAuther.credentials(
-        consumer_secret: "kd94hf93k423kf44",
-        token_secret: "pfkkdhi9sl3r4s00",
-        consumer_key: "dpf43f3p2l4k3l03",
-        token: "nnch734d00sl2jdk"
-      )
+    test "signature with query params" do
+      creds =
+        OAuther.credentials(
+          consumer_secret: "kd94hf93k423kf44",
+          token_secret: "pfkkdhi9sl3r4s00",
+          consumer_key: "dpf43f3p2l4k3l03",
+          token: "nnch734d00sl2jdk"
+        )
 
-    params = protocol_params(creds)
-    assert signature(params, creds, "/photos?size=large") == "dzTFIxhRqhwfFqoXYgo4+hoPr2M="
+      params = protocol_params(creds)
+      assert signature(params, creds, "/photos?size=large") == "dzTFIxhRqhwfFqoXYgo4+hoPr2M="
+    end
   end
 
   test "Authorization header" do

--- a/test/oauther_test.exs
+++ b/test/oauther_test.exs
@@ -1,6 +1,24 @@
 defmodule OAutherTest do
   use ExUnit.Case
 
+  describe "header/1" do
+    test "Authorization header" do
+      {header, req_params} =
+        OAuther.header([
+          {"oauth_consumer_key", "dpf43f3p2l4k3l03"},
+          {"oauth_signature_method", "PLAINTEXT"},
+          {"oauth_signature", "kd94hf93k423kf44&"},
+          {"build", "Luna Park"}
+        ])
+
+      assert header ==
+               {"Authorization",
+                ~S(OAuth oauth_consumer_key="dpf43f3p2l4k3l03", oauth_signature_method="PLAINTEXT", oauth_signature="kd94hf93k423kf44%26")}
+
+      assert req_params == [{"build", "Luna Park"}]
+    end
+  end
+
   describe "signature/4" do
     test "HMAC-SHA1 signature" do
       creds =
@@ -80,22 +98,6 @@ defmodule OAutherTest do
       params = protocol_params(creds)
       assert signature(params, creds, "/photos?size=large") == "dzTFIxhRqhwfFqoXYgo4+hoPr2M="
     end
-  end
-
-  test "Authorization header" do
-    {header, req_params} =
-      OAuther.header([
-        {"oauth_consumer_key", "dpf43f3p2l4k3l03"},
-        {"oauth_signature_method", "PLAINTEXT"},
-        {"oauth_signature", "kd94hf93k423kf44&"},
-        {"build", "Luna Park"}
-      ])
-
-    assert header ==
-             {"Authorization",
-              ~S(OAuth oauth_consumer_key="dpf43f3p2l4k3l03", oauth_signature_method="PLAINTEXT", oauth_signature="kd94hf93k423kf44%26")}
-
-    assert req_params == [{"build", "Luna Park"}]
   end
 
   defp fixture_path(file_path) do

--- a/test/oauther_test.exs
+++ b/test/oauther_test.exs
@@ -1,6 +1,47 @@
 defmodule OAutherTest do
   use ExUnit.Case
 
+  describe "credentials/1" do
+    test "returns Credentials struct" do
+      assert %OAuther.Credentials{
+               consumer_key: "dpf43f3p2l4k3l03",
+               consumer_secret: "kd94hf93k423kf44",
+               method: :hmac_sha1,
+               token: "nnch734d00sl2jdk",
+               token_secret: "pfkkdhi9sl3r4s00"
+             } ==
+               OAuther.credentials(
+                 consumer_key: "dpf43f3p2l4k3l03",
+                 consumer_secret: "kd94hf93k423kf44",
+                 token: "nnch734d00sl2jdk",
+                 token_secret: "pfkkdhi9sl3r4s00"
+               )
+    end
+  end
+
+  describe "sign/4" do
+    test "returns list of params with oauth_signature" do
+      creds =
+        OAuther.credentials(
+          consumer_secret: "kd94hf93k423kf44",
+          token_secret: "pfkkdhi9sl3r4s00",
+          consumer_key: "dpf43f3p2l4k3l03",
+          token: "nnch734d00sl2jdk"
+        )
+
+      assert [
+               {"oauth_signature", _},
+               {"oauth_token", "nnch734d00sl2jdk"},
+               {"oauth_consumer_key", "dpf43f3p2l4k3l03"},
+               {"oauth_nonce", _},
+               {"oauth_signature_method", "HMAC-SHA1"},
+               {"oauth_timestamp", _},
+               {"oauth_version", "1.0"},
+               {"custom_param", "123"}
+             ] = OAuther.sign("get", "http://test.com", [{"custom_param", "123"}], creds)
+    end
+  end
+
   describe "header/1" do
     test "Authorization header" do
       {header, req_params} =
@@ -16,6 +57,28 @@ defmodule OAutherTest do
                 ~S(OAuth oauth_consumer_key="dpf43f3p2l4k3l03", oauth_signature_method="PLAINTEXT", oauth_signature="kd94hf93k423kf44%26")}
 
       assert req_params == [{"build", "Luna Park"}]
+    end
+  end
+
+  describe "protocol_params/2" do
+    test "returns params list with protocol params" do
+      creds =
+        OAuther.credentials(
+          consumer_secret: "kd94hf93k423kf44",
+          token_secret: "pfkkdhi9sl3r4s00",
+          consumer_key: "dpf43f3p2l4k3l03",
+          token: "nnch734d00sl2jdk"
+        )
+
+      assert [
+               {"oauth_token", "nnch734d00sl2jdk"},
+               {"oauth_consumer_key", "dpf43f3p2l4k3l03"},
+               {"oauth_nonce", _},
+               {"oauth_signature_method", "HMAC-SHA1"},
+               {"oauth_timestamp", _},
+               {"oauth_version", "1.0"},
+               {"custom_param", "123"}
+             ] = OAuther.protocol_params([{"custom_param", "123"}], creds)
     end
   end
 

--- a/test/oauther_test.exs
+++ b/test/oauther_test.exs
@@ -8,7 +8,26 @@ defmodule OAutherTest do
                consumer_secret: "kd94hf93k423kf44",
                method: :hmac_sha1,
                token: "nnch734d00sl2jdk",
-               token_secret: "pfkkdhi9sl3r4s00"
+               token_secret: "pfkkdhi9sl3r4s00",
+               realm: "Photos"
+             } ==
+               OAuther.credentials(
+                 consumer_key: "dpf43f3p2l4k3l03",
+                 consumer_secret: "kd94hf93k423kf44",
+                 token: "nnch734d00sl2jdk",
+                 token_secret: "pfkkdhi9sl3r4s00",
+                 realm: "Photos"
+               )
+    end
+
+    test "by default realm is set to nil" do
+      assert %OAuther.Credentials{
+               consumer_key: "dpf43f3p2l4k3l03",
+               consumer_secret: "kd94hf93k423kf44",
+               method: :hmac_sha1,
+               token: "nnch734d00sl2jdk",
+               token_secret: "pfkkdhi9sl3r4s00",
+               realm: nil
              } ==
                OAuther.credentials(
                  consumer_key: "dpf43f3p2l4k3l03",
@@ -26,11 +45,13 @@ defmodule OAutherTest do
           consumer_secret: "kd94hf93k423kf44",
           token_secret: "pfkkdhi9sl3r4s00",
           consumer_key: "dpf43f3p2l4k3l03",
-          token: "nnch734d00sl2jdk"
+          token: "nnch734d00sl2jdk",
+          realm: "Photos"
         )
 
       assert [
                {"oauth_signature", _},
+               {"realm", "Photos"},
                {"oauth_token", "nnch734d00sl2jdk"},
                {"oauth_consumer_key", "dpf43f3p2l4k3l03"},
                {"oauth_nonce", _},
@@ -49,12 +70,13 @@ defmodule OAutherTest do
           {"oauth_consumer_key", "dpf43f3p2l4k3l03"},
           {"oauth_signature_method", "PLAINTEXT"},
           {"oauth_signature", "kd94hf93k423kf44&"},
+          {"realm", "Photos"},
           {"build", "Luna Park"}
         ])
 
       assert header ==
                {"Authorization",
-                ~S(OAuth oauth_consumer_key="dpf43f3p2l4k3l03", oauth_signature_method="PLAINTEXT", oauth_signature="kd94hf93k423kf44%26")}
+                ~S(OAuth oauth_consumer_key="dpf43f3p2l4k3l03", oauth_signature_method="PLAINTEXT", oauth_signature="kd94hf93k423kf44%26", realm="Photos")}
 
       assert req_params == [{"build", "Luna Park"}]
     end
@@ -67,7 +89,30 @@ defmodule OAutherTest do
           consumer_secret: "kd94hf93k423kf44",
           token_secret: "pfkkdhi9sl3r4s00",
           consumer_key: "dpf43f3p2l4k3l03",
-          token: "nnch734d00sl2jdk"
+          token: "nnch734d00sl2jdk",
+          realm: "Photos"
+        )
+
+      assert [
+               {"realm", "Photos"},
+               {"oauth_token", "nnch734d00sl2jdk"},
+               {"oauth_consumer_key", "dpf43f3p2l4k3l03"},
+               {"oauth_nonce", _},
+               {"oauth_signature_method", "HMAC-SHA1"},
+               {"oauth_timestamp", _},
+               {"oauth_version", "1.0"},
+               {"custom_param", "123"}
+             ] = OAuther.protocol_params([{"custom_param", "123"}], creds)
+    end
+
+    test "when realm is not present it's not included in the list of protocol params" do
+      creds =
+        OAuther.credentials(
+          consumer_secret: "kd94hf93k423kf44",
+          token_secret: "pfkkdhi9sl3r4s00",
+          consumer_key: "dpf43f3p2l4k3l03",
+          token: "nnch734d00sl2jdk",
+          realm: nil
         )
 
       assert [
@@ -160,6 +205,20 @@ defmodule OAutherTest do
 
       params = protocol_params(creds)
       assert signature(params, creds, "/photos?size=large") == "dzTFIxhRqhwfFqoXYgo4+hoPr2M="
+    end
+
+    test "signature with realm" do
+      creds =
+        OAuther.credentials(
+          consumer_secret: "kd94hf93k423kf44",
+          token_secret: "pfkkdhi9sl3r4s00",
+          consumer_key: "dpf43f3p2l4k3l03",
+          token: "nnch734d00sl2jdk",
+          realm: "Photos"
+        )
+
+      params = protocol_params(creds)
+      assert signature(params, creds, "/photos") == "9QG3oRtIpkf/+slqLB7SDlccBZU="
     end
   end
 


### PR DESCRIPTION
This PR adds support for the realm protocol param as described in [rfc5849](https://datatracker.ietf.org/doc/html/rfc5849).

It also contains a few unrelated/minor improvements.

Best reviewed commit by commit.
