### PR TITLE
Expose base_string and decode_private_key

### DIFF
--- a/lib/oauther.ex
+++ b/lib/oauther.ex
@@ -117,7 +117,7 @@ defmodule OAuther do
     File.read!(path)
   end
 
-  defp decode_private_key(private_key_or_path) do
+  def decode_private_key(private_key_or_path) do
     [entry] =
       private_key_or_path
       |> read_private_key()
@@ -126,7 +126,7 @@ defmodule OAuther do
     :public_key.pem_entry_decode(entry)
   end
 
-  defp base_string(verb, url, params) do
+  def base_string(verb, url, params) do
     {uri, query_params} = parse_url(url)
 
     [verb, uri, params ++ query_params]


### PR DESCRIPTION
I have the unfortunate privledge of working with an API that has customized OAuth 1.0a in such a way to require a custom `signature` function -- in some instances.

Specifically, they've prepended a token to the request before computing the signature. 

```
(prefix <> OAuther.base_string(verb, url, params))
|> :public_key.sign(:sha256, OAuther.decode_private_key(creds.consumer_secret))
|> Base.encode64()
```

Rather than pollute the oauther library with such things, I was hoping that it would be okay to expose a few of the internal functions to make it easier to do this hackery (without requiring that I maintain a separate fork or copy/paste as much of your code).

Let me know what you think. Thanks!